### PR TITLE
Exclude Commons Logging from HttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,17 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.5</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>1.7.5</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Maven uses SLF4J but Apache HttpClient uses Commons Logging.
This change removes commons logging but instead bridges commons logging to SLF4J