### PR TITLE
Add support for "insecure"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Maven Coordinates:
               <skip>false</skip><!-- this is the default -->
               <chatty>false</chatty><!-- this is the default -->
               <quiet>false</quiet><!-- this is the default -->
+              <insecure>false</insecure><!-- this is the default -->
               <timeoutSeconds>30</timeoutSeconds><!-- this is the default -->
               <checkEveryMillis>500</checkEveryMillis><!-- this is the default -->
               <checks>
@@ -86,3 +87,11 @@ Maven Coordinates:
           </execution>
         </executions>
       </plugin>
+
+## Options
+
+### insecure
+
+The `insecure` flag allows bypassing https certificate checks. This is handy when using self-signed certificates for
+example.
+

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>waitfor-maven-plugin</artifactId>
 
   <packaging>maven-plugin</packaging>
-  <version>1.3</version>
+  <version>1.4-SNAPSHOT</version>
 
   <name>Simplaex WaitFor Maven Plugin</name>
   <description>Wait one or more URLs are accessible via HTTP</description>


### PR DESCRIPTION
We add a support for `insecure` option (default to `false`).

The `insecure` flag allows bypassing https certificate checks. This is handy when using self-signed certificates for
example.

I tested it locally with a secured 8.1 elasticsearch cluster using a self generated certificate. 
Before that change it was failing. It's now passing.

Closes #8.